### PR TITLE
Django <= 1.8 compatibility and travisci with tox tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ env:
   - TOX_ENV=py33-django16
   - TOX_ENV=py33-django17
   - TOX_ENV=py33-django18
+  - TOX_ENV=py34-django15
+  - TOX_ENV=py34-django16
+  - TOX_ENV=py34-django17
+  - TOX_ENV=py34-django18
 install:
   - pip install tox
 script: tox -e $TOX_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+language: python
+python:
+  - "2.7"
+env:
+  - TOX_ENV=py26-django14
+  - TOX_ENV=py26-django15
+  - TOX_ENV=py26-django16
+  - TOX_ENV=py27-django14
+  - TOX_ENV=py27-django15
+  - TOX_ENV=py27-django16
+  - TOX_ENV=py27-django17
+  - TOX_ENV=py27-django18
+  - TOX_ENV=py33-django15
+  - TOX_ENV=py33-django16
+  - TOX_ENV=py33-django17
+  - TOX_ENV=py33-django18
+install:
+  - pip install tox
+script: tox -e $TOX_ENV
+

--- a/json_field/forms.py
+++ b/json_field/forms.py
@@ -2,10 +2,15 @@ try:
     import json
 except ImportError:  # python < 2.6
     from django.utils import simplejson as json
-from django.forms import fields, util
+try:
+    from django.forms import utils
+except ImportError:  # django < 1.7
+    from django.forms import util as utils
+from django.forms import fields
 
 import datetime
 from decimal import Decimal
+
 
 class JSONFormField(fields.Field):
 
@@ -13,8 +18,8 @@ class JSONFormField(fields.Field):
         from .fields import JSONEncoder, JSONDecoder
 
         self.evaluate = kwargs.pop('evaluate', False)
-        self.encoder_kwargs = kwargs.pop('encoder_kwargs', {'cls':JSONEncoder})
-        self.decoder_kwargs = kwargs.pop('decoder_kwargs', {'cls':JSONDecoder, 'parse_float':Decimal})
+        self.encoder_kwargs = kwargs.pop('encoder_kwargs', {'cls': JSONEncoder})
+        self.decoder_kwargs = kwargs.pop('decoder_kwargs', {'cls': JSONDecoder, 'parse_float': Decimal})
 
         kwargs.pop('max_length', None)
 
@@ -45,9 +50,9 @@ class JSONFormField(fields.Field):
             try:
                 value = json.dumps(eval(value, json_globals, json_locals), **self.encoder_kwargs)
             except Exception as e: # eval can throw many different errors
-                raise util.ValidationError(str(e))
+                raise utils.ValidationError(str(e))
 
         try:
             return json.loads(value, **self.decoder_kwargs)
         except ValueError as e:
-            raise util.ValidationError(str(e))
+            raise utils.ValidationError(str(e))

--- a/manage.py
+++ b/manage.py
@@ -2,6 +2,15 @@
 import os
 import sys
 
+try:
+    import test_project.settings as settings_mod  # Assumed to be in the test_project directory.
+except ImportError:
+    sys.stderr.write("Error: Can't find the file 'settings.py' in the test_project directory. It appears you've customized things.\nYou'll have to run django-admin.py, passing it your settings module.\n(If the file settings.py does indeed exist, it's causing an ImportError somehow.)\n" % __file__)
+    sys.exit(1)
+
+sys.path.insert(0, settings_mod.PROJECT_ROOT)
+sys.path.insert(0, settings_mod.PROJECT_ROOT + '/../')
+
 if __name__ == "__main__":
     os.environ.setdefault("DJANGO_SETTINGS_MODULE", "test_project.settings")
 

--- a/test_project/app/forms.py
+++ b/test_project/app/forms.py
@@ -5,15 +5,20 @@ from .models import Test
 from django import forms
 from json_field.forms import JSONFormField
 
+
 class ModelForm(forms.ModelForm):
     class Meta:
         model = Test
+        exclude = []
+
 
 class TestForm(forms.Form):
     json = JSONFormField()
 
+
 class OptionalForm(forms.Form):
     json = JSONFormField(required=False)
+
 
 class EvalForm(forms.Form):
     json = JSONFormField(evaluate=True)

--- a/test_project/app/tests.py
+++ b/test_project/app/tests.py
@@ -79,10 +79,10 @@ class JSONFieldTest(TestCase):
     def test_decimal(self):
         t1 = Test.objects.create(json=1.24)
         self.assertEqual(Decimal('1.24'), Test.objects.get(pk=t1.pk).json)
-        t2 = Test.objects.create(json=Decimal(1.24))
-        self.assertEqual(str(Decimal(1.24)), Test.objects.get(pk=t2.pk).json)
-        t3 = Test.objects.create(json={'test':[{'test':Decimal(1.24)}]})
-        self.assertEqual({'test':[{'test':str(Decimal(1.24))}]}, Test.objects.get(pk=t3.pk).json)
+        t2 = Test.objects.create(json=Decimal('1.24'))
+        self.assertEqual(str(Decimal('1.24')), Test.objects.get(pk=t2.pk).json)
+        t3 = Test.objects.create(json={'test':[{'test':Decimal('1.24')}]})
+        self.assertEqual({'test':[{'test':str(Decimal('1.24'))}]}, Test.objects.get(pk=t3.pk).json)
 
     def test_time(self):
         now = datetime.datetime.now().time()

--- a/test_project/settings.py
+++ b/test_project/settings.py
@@ -1,4 +1,8 @@
-# Django settings for test_project project.
+import os
+
+from django import VERSION
+
+PROJECT_ROOT = os.path.realpath(os.path.dirname(__file__))
 
 DEBUG = True
 TEMPLATE_DEBUG = DEBUG
@@ -152,3 +156,6 @@ LOGGING = {
         },
     }
 }
+
+if VERSION >= (1, 6):
+    TEST_RUNNER = 'django.test.runner.DiscoverRunner'

--- a/tox.ini
+++ b/tox.ini
@@ -3,6 +3,7 @@ envlist =
     py26-django{14,15,16},
     py27-django{14,15,16,17,18},
     py33-django{15,16,17,18}
+    py34-django{15,16,17,18}
 
 [testenv]
 commands = python manage.py test app

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist =
+    py26-django{14,15,16},
+    py27-django{14,15,16,17,18},
+    py33-django{15,16,17,18}
+
+[testenv]
+commands = python manage.py test app
+deps =
+    django14: Django>=1.4, <1.5
+    django15: Django>=1.5, <1.6
+    django16: Django>=1.6, <1.7
+    django17: Django>=1.7, <1.8
+    django18: Django>=1.8, <1.9
+


### PR DESCRIPTION
Fixes to run on Django 1.4 to 1.8.

Add tox.ini to run tests.
